### PR TITLE
add value to render for Datepicker

### DIFF
--- a/lib/Date.js
+++ b/lib/Date.js
@@ -57,6 +57,8 @@ var Date = (function (_React$Component) {
                 'div',
                 { style: { width: '100%', display: 'block' } },
                 _react2['default'].createElement(DatePicker, {
+                    // TODO: transpile from src
+                    value: this.props.value,
                     mode: "landscape",
                     autoOk: true,
                     hintText: this.props.form.title,


### PR DESCRIPTION
This was added in the src/Date file, but needs to be transpiled to ECMA5 or others won't have the changes necessary.
Users of this library will have a similar issue when using the minified versions of react-schema-form.

The best thing to do would be to transpile the changes and update the repository. I might do that at some future point in time.
